### PR TITLE
Patch without overlap: patch full image

### DIFF
--- a/procs/impatch.py
+++ b/procs/impatch.py
@@ -58,14 +58,25 @@ class impatchify(object):
             raise ValueError('Patch size ({}) must be lesser than image dimension {}'.format(patch_size, dim))
 
         img_patches = []
+        rows, cols = img.shape[0:2]
 
-        # size of cropped image
-        npatch_row = (img.shape[0] // patch_size)
-        npatch_col = (img.shape[1] // patch_size)
+        npatch_row = (rows // patch_size) + 1 if (rows % patch_size) != 0 else 0
+        npatch_col = (cols // patch_size) + 1 if (cols % patch_size) != 0 else 0
 
-        for y in range(0, npatch_row):
-            for x in range(0, npatch_col):
-                img_patch = img[y * patch_size:(y + 1) * patch_size, x * patch_size:(x + 1) * patch_size]
+        for y in range(npatch_row):
+            for x in range(npatch_col):
+
+                if (x + 1) * patch_size < cols:
+                    c_start, c_end = x * patch_size, (x + 1) * patch_size
+                else:
+                    c_start, c_end = x * patch_size - ((x + 1) * patch_size - cols), cols
+
+                if (y + 1) * patch_size < rows:
+                    r_start, r_end = y * patch_size, (y + 1) * patch_size
+                else:
+                    r_start, r_end = y * patch_size - ((y + 1) * patch_size - rows), rows
+
+                img_patch = img[r_start:r_end, c_start:c_end]
                 img_patches.append(img_patch)
 
         return img_patches
@@ -80,7 +91,7 @@ class impatchify(object):
             raise ValueError('Overlap ratio must be non-negative float!')
 
         # set function that performs splitting image into patches
-        fn_patch = impatchify.__pathifyOverlap(overlap_ratio) if overlap_ratio > 0. else impatchify.__patchifyImg
+        fn_patch = impatchify.__pathifyOverlap(overlap_ratio) if overlap_ratio > 0. else impatchify.__patchifyImg2
 
         img_patches = []
 

--- a/tests/test_impatch.py
+++ b/tests/test_impatch.py
@@ -1,0 +1,48 @@
+import os
+
+import cv2 as opencv
+import numpy as np
+import matplotlib.pylab as plt
+
+from procs.impatch import impatchify
+from utils.plots import imshow
+
+
+DATA_DIR = 'datasets/DRIVE/training/'
+IMG_NAME = '21_training'
+PATCH_SIZE = 128
+
+tst_file_img = os.path.join(DATA_DIR, 'images/{}.tif'.format(IMG_NAME))
+tst_img = opencv.imread(tst_file_img, opencv.IMREAD_COLOR)
+
+img_patches = impatchify.getPatches(
+        imgs=[tst_img],
+        patch_size=PATCH_SIZE,
+        overlap_ratio=0.
+)
+
+# merge patches into image
+height, width = tst_img.shape[0:2]
+img_merged = np.zeros(shape=tst_img.shape, dtype=tst_img.dtype)
+
+c, r = 1, 1
+for patch in img_patches:
+    r_start, r_end = PATCH_SIZE * (r - 1), PATCH_SIZE * r
+    c_start, c_end = PATCH_SIZE * (c - 1), PATCH_SIZE * c
+
+    patch_rs = r_end - height if r_end > height else 0
+
+    if c_end < width:
+        img_merged[r_start:r_end, c_start:c_end, :] = patch[patch_rs:]
+
+        c += 1
+    else:
+        patch_cs = c_end - width
+        img_merged[r_start:r_end, c_start:c_end, :] = patch[patch_rs:, patch_cs:]
+
+        r += 1; c = 1
+
+imshow(img_merged)
+plt.show()
+
+assert np.max(img_merged - tst_img) == 0, f'Error patchify image'


### PR DESCRIPTION
This pull request contains improvements of an implementation related to patching image without overlap. Now, an implemetations supports patchifying full image, not as a previous implementation that crops an input image such that its shape is multiple by A patch size. Test of this new functionality was also added.

* procs/adapter.py
* procs/impatch.py
* tests/test_impatch.py